### PR TITLE
Snap build yaml for pciids

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,29 @@
+name: pciids
+adopt-info: pciids
+summary: Lookup vendor and device names using PCI IDs!
+description: |
+  Lookup vendor and device names using PCI IDs!
+  
+base: core20
+grade: stable
+confinement: strict
+compression: lzo
+
+license: GPL-3.0
+
+apps:
+  pciids:
+    command: bin/pciids
+    plugs:
+      - home
+      - network
+      
+parts:
+  pciids:
+    source: https://github.com/powersj/pciids 
+    source-type: git
+    plugin: go
+      
+    override-pull: |
+      snapcraftctl pull
+      snapcraftctl set-version "$(git describe --tags | sed 's/^v//' | cut -d "-" -f1)"


### PR DESCRIPTION
I built a snap for `pciids` locally. It isn't registered with the snapstore, so I thought I'd contribute to your work with this PR. 

Not sure if you're interested in deploying as a snap, and you may see deficiencies with this layout, but it seems to work well locally. 